### PR TITLE
Minor documentation fixes and clean up formatting of JSON & CLI examples

### DIFF
--- a/doc_source/code-sign-policy.md
+++ b/doc_source/code-sign-policy.md
@@ -21,9 +21,7 @@ In production environments, you should digitally sign your firmware update to en
          "Action": [
            "signer:*"
          ],
-         "Resource": [
-           "*"
-         ]
+         "Resource": "*"
        }
      ]
    }

--- a/doc_source/create-service-role.md
+++ b/doc_source/create-service-role.md
@@ -45,17 +45,18 @@ For more information about IAM roles, see [IAM Roles](https://docs.aws.amazon.co
 1. Copy and paste the following policy document into the text box:
 
    ```
-   {
-       "Version": "2012-10-17",
-       "Statement": [{
-               "Effect": "Allow",
-               "Action": [
-                   "iam:GetRole",
-                   "iam:PassRole"
-               ],
-               "Resource": 
-               "arn:aws:iam::<your_account_id>:role/<your_role_name>"
-       }]
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "iam:GetRole",
+            "iam:PassRole"
+          ],
+          "Resource": "arn:aws:iam::<your_account_id>:role/<your_role_name>"
+        }
+      ]
    }
    ```
 
@@ -77,15 +78,18 @@ For more information about IAM roles, see [IAM Roles](https://docs.aws.amazon.co
 
    ```
    {
-       "Version": "2012-10-17",
-       "Statement": [{
-               "Effect": "Allow",
-               "Action": [
-                   "s3:GetObjectVersion",
-                   "s3:GetObject"
-               ],
-               "Resource": "arn:aws:s3:::<example-bucket>/*"
-       }]
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "s3:GetObjectVersion",
+           "s3:GetObject",
+           "s3:PutObject"
+         ],
+         "Resource": "arn:aws:s3:::<example-bucket>/*"
+       }
+     ]
    }
    ```
 

--- a/doc_source/gg-demo.md
+++ b/doc_source/gg-demo.md
@@ -45,13 +45,11 @@ You can also connect your board to AWS IoT and configure your Amazon FreeRTOS de
 
       ```
       {
-            "Effect": "Allow",
-            "Action": [
-              "greengrass:*"
-            ],
-            "Resource": [
-              "*"
-            ]
+        "Effect": "Allow",
+        "Action": [
+          "greengrass:*"
+        ],
+        "Resource": "*"
       }
       ```
 

--- a/doc_source/ota-cli-workflow.md
+++ b/doc_source/ota-cli-workflow.md
@@ -19,18 +19,18 @@ To sign your firmware image using Code Signing for AWS IoT, you must install the
 After you install and configure the code signing tools, copy your unsigned firmware image to your Amazon S3 bucket and start a code signing job with the following CLI commands\. The `put-signing-profile` command creates a reusable code\-signing profile\. The `start-signing-job` command starts the signing job\.
 
 ```
-aws signer put-signing-profile --profile-name <your_profile_name>
-							--signing-material certificateArn=
-							arn:aws:acm::<your-region>:<your-aws-account-id>:certificate/<your-certificate-id>
-								--platform <your-hardware-platform> --signing-parameters
-							certname=<your_certificate_path_on_device>
+aws signer put-signing-profile \
+    --profile-name <your_profile_name> \
+    --signing-material certificateArn=arn:aws:acm::<your-region>:<your-aws-account-id>:certificate/<your-certificate-id> \
+    --platform <your-hardware-platform> \
+    --signing-parameters certname=<your_certificate_path_on_device>
 ```
 
 ```
-aws signer start-signing-job --source
-							's3={bucketName=<your_s3_bucket>,key=<your_s3_object_key>,version=<your_s3_object_version_id>}'
-								--destination 's3={bucketName=<your_destination_bucket>}' --profile-name
-							<your_profile_name>
+aws signer start-signing-job \
+    --source 's3={bucketName=<your_s3_bucket>,key=<your_s3_object_key>,version=<your_s3_object_version_id>}' \
+    --destination 's3={bucketName=<your_destination_bucket>}' \
+    --profile-name <your_profile_name>
 ```
 
 **Note**  
@@ -71,13 +71,13 @@ The OTA Update service sends updates over MQTT messages\. To do this, you must c
 
 ```
 [
-	{
-    	"fileId":<your_file_id>,
-		"s3Location":{
-		    "bucket":"<your_bucket_name>",
-	    	"key":"<your_s3_object_key<"
-		}
-	}	
+  {
+    "fileId":<your_file_id>,
+    "s3Location":{
+      "bucket":"<your_bucket_name>",
+      "key":"<your_s3_object_key<"
+    }
+  }	
 ]
 ```
 
@@ -96,7 +96,11 @@ The file name of your signed firmware image in the Amazon S3 bucket\. You can fi
 Use the `create-stream` CLI command to create a stream:
 
 ```
-aws iot create-stream --stream-id <your_stream_id> --description <your_description> --files file://<stream.json> --role-arn <your_role_arn>
+aws iot create-stream \
+    --stream-id <your_stream_id> \
+    --description <your_description> \
+    --files file://<stream.json> \
+    --role-arn <your_role_arn>
 ```
 
 The following list describes the arguments for the `create-stream` CLI command\.
@@ -123,7 +127,7 @@ The following is an example stream\.json file:
 [
 	{
 		"fileId":123,
-		"s3Location":{
+		"s3Location": {
 			"bucket":"codesign-ota-bucket",
 			"key":"48c67f3c-63bb-4f92-a98a-4ee0fbc2bef6"
 		}
@@ -138,13 +142,12 @@ To find the Amazon S3 object key of your signed firmware image, use the `aws sig
 
 ```
 ... text deleted for brevity ...
-	"signedObject": {
-		"s3": {
-			"bucketName": "ota-bucket",
-			"key": "7309da2c-9111-48ac-8ee4-5a4262af4429"
-		}
-	}
-
+  "signedObject": {
+    "s3": {
+      "bucketName": "ota-bucket",
+      "key": "7309da2c-9111-48ac-8ee4-5a4262af4429"
+    }
+  }
 ... text deleted for brevity ...
 ```
 
@@ -153,7 +156,13 @@ To find the Amazon S3 object key of your signed firmware image, use the `aws sig
 Use the `create-ota-update` CLI command to create an OTA update job:
 
 ```
-aws iot create-ota-update --ota-update-id "<my_ota_update>" --target-selection SNAPSHOT --description "<a cli ota update>" --files file://<ota.json> --targets arn:aws:iot:<your-aws-region>:<your-aws-account>:thing/<your-thing-name> --role-arn arn:aws:iam::<your-aws-account>:role/<your-ota-service-role
+aws iot create-ota-update \
+    --ota-update-id "<my_ota_update>" \
+    --target-selection SNAPSHOT \
+    --description "<a cli ota update>" \
+    --files file://<ota.json> \
+    --targets arn:aws:iot:<your-aws-region>:<your-aws-account>:thing/<your-thing-name> \
+    --role-arn arn:aws:iam::<your-aws-account>:role/<your-ota-service-role
 ```
 
 **Note**  
@@ -219,18 +228,18 @@ The following is an example of a JSON file passed into the create\-ota\-update c
 
 ```
 [
-	{
-    	"fileName": "firmware.bin",                              
-    	"fileLocation": {
-	        "stream": {
-    	        "streamId": "004",                                               
-            	"fileId":123
-        	}                                                
-    	},
-    	"codeSigning": {
-        	"awsSignerJobId": "48c67f3c-63bb-4f92-a98a-4ee0fbc2bef6"         
-    	}
-	}
+  {
+    "fileName": "firmware.bin",                              
+    "fileLocation": {
+      "stream": {
+        "streamId": "004",                                               
+        "fileId":123
+      }                                                
+    },
+    "codeSigning": {
+      "awsSignerJobId": "48c67f3c-63bb-4f92-a98a-4ee0fbc2bef6"         
+    }
+  }
 ]
 ```
 
@@ -238,28 +247,28 @@ The following is an example of a JSON file passed into the create\-ota\-update C
 
 ```
 [
-	{
-	    "fileName": "firmware.bin",
-    	"fileLocation": {
-	        "stream": {
-    	        "streamId": "004",
-        	    "fileId": 123
-        	}
-    	},
-    	"codeSigning": {
-        	"customCodeSigning":{
-            	"signature":{
-                	"inlineDocument":"<your_signature>"
-            	},
-            	"certificateChain": {
-            		"certificateName": "<your_certificate_name>
-                	"inlineDocument":"<your_certificate_chain>"
-            	},
-            	"hashAlgorithm":"<your_hash_algorithm>",
-            	"signatureAlgorithm":"<your_signature_algorithm>"
-        	}
-    	}
-	}
+  {
+    "fileName": "firmware.bin",
+    "fileLocation": {
+      "stream": {
+        "streamId": "004",
+        "fileId": 123
+      }
+    },
+    "codeSigning": {
+      "customCodeSigning":{
+        "signature":{
+          "inlineDocument":"<your_signature>"
+        },
+        "certificateChain": {
+          "certificateName": "<your_certificate_name>",
+          "inlineDocument":"<your_certificate_chain>"
+        },
+        "hashAlgorithm":"<your_hash_algorithm>",
+        "signatureAlgorithm":"<your_signature_algorithm>"
+      }
+    }
+  }
 ]
 ```
 
@@ -267,32 +276,32 @@ The following is an example of a JSON file passed into the create\-ota\-update C
 
 ```
 [
-	{
-		"fileName": "<your_firmware_path_on_device>",
-		"fileVersion": "1",
-		"fileLocation": {
-			"s3Location": {
-				"bucket": "<your_bucket_name>",
-				"key": "<your_object_key>",
-				"version": "<your_S3_object_version>"
-			}
-		},
-		"codeSigning":{
-			"startSigningJobParameter":{
-				"signingProfileName": "myTestProfile",
-				"signingProfileParameter": {
-					"certificateArn": "<your_certificate_arn>",
-					"platformId": "<your_platform_id>",
-					"certificatePathOnDevice": "<certificate_path>"
-				},
-				"destination": {
-					"s3Destination": {
-						"bucket": "<your_destination_bucket>"
-					}
-				}
-			}
-		}    
-	}
+  {
+    "fileName": "<your_firmware_path_on_device>",
+    "fileVersion": "1",
+    "fileLocation": {
+      "s3Location": {
+        "bucket": "<your_bucket_name>",
+        "key": "<your_object_key>",
+        "version": "<your_S3_object_version>"
+      }
+    },
+    "codeSigning":{
+      "startSigningJobParameter":{
+        "signingProfileName": "myTestProfile",
+        "signingProfileParameter": {
+          "certificateArn": "<your_certificate_arn>",
+          "platform": "<your_platform_id>",
+          "certificatePathOnDevice": "<certificate_path>"
+        },
+        "destination": {
+          "s3Destination": {
+            "bucket": "<your_destination_bucket>"
+          }
+        }
+      }
+    }
+  }
 ]
 ```
 
@@ -300,27 +309,27 @@ The following is an example of a JSON file passed into the create\-ota\-update C
 
 ```
 [
-	{
-	"fileName": "<your_firmware_path_on_device>",
-		"fileVersion": "1",
-		"fileLocation": {
-			"s3Location": {
-				"bucket": "<your_bucket_name>",
-				"key": "<your_object_key>",
-				"version": "<your_S3_object_version>"
-			}
-		},
-		"codeSigning":{
-			"startSigningJobParameter":{
-				"signingProfileName": "<your_unique_profile_name>",
-				"destination": {
-					"s3Destination": {
-						"bucket": "<our_destination_bucket>"
-					}
-				}
-			}
-		}    
-	}
+  {
+    "fileName": "<your_firmware_path_on_device>",
+    "fileVersion": "1",
+    "fileLocation": {
+      "s3Location": {
+        "bucket": "<your_bucket_name>",
+        "key": "<your_object_key>",
+        "version": "<your_S3_object_version>"
+      }
+    },
+    "codeSigning":{
+      "startSigningJobParameter":{
+        "signingProfileName": "<your_unique_profile_name>",
+        "destination": {
+          "s3Destination": {
+            "bucket": "<our_destination_bucket>"
+          }
+        }
+      }
+    }    
+  }
 ]
 ```
 
@@ -328,13 +337,13 @@ The following is an example of a JSON file passed into the create\-ota\-update C
 
 ```
 [
-	{
-		"fileName": "<your_firmware_path_on_device>",
-		"fileVersion": "1",
-		"codeSigning":{
-			"awsSignerJobId": "<your_signer_job_id>"
-		}    
-	}
+  {
+    "fileName": "<your_firmware_path_on_device>",
+    "fileVersion": "1",
+    "codeSigning":{
+      "awsSignerJobId": "<your_signer_job_id>"
+    }    
+  }
 ]
 ```
 
@@ -342,30 +351,30 @@ The following is an example of a JSON file passed into the create\-ota\-update C
 
 ```
 [
-	{
-		"fileName": "<your_firmware_path_on_device>",
-		"fileVersion": "1",
-		"fileLocation": {
-			"s3Location": {
-				"bucket": "<your_bucket_name>",
-				"key": "<your_object_key>",
-				"version": "<your_S3_object_version>"
-			}
-		},
-		"codeSigning":{
-			"customCodeSigning": {
-				"signature":{
-					"inlineDocument":"<your_signature>"
-				},
-				"certificateChain": {
-					"inlineDocument":"<your_certificate_chain>",
-					"certificateName": "<your_certificate_path_on_device>"
-				},
-				"hashAlgorithm":"<your_hash_algorithm>",
-				"signatureAlgorithm":"<your_sig_algorithm>"
-			}
-		}    
-	}
+  {
+    "fileName": "<your_firmware_path_on_device>",
+    "fileVersion": "1",
+    "fileLocation": {
+        "s3Location": {
+          "bucket": "<your_bucket_name>",
+          "key": "<your_object_key>",
+          "version": "<your_S3_object_version>"
+        }
+    },
+    "codeSigning":{
+      "customCodeSigning": {
+        "signature":{
+          "inlineDocument":"<your_signature>"
+        },
+        "certificateChain": {
+          "inlineDocument":"<your_certificate_chain>",
+          "certificateName": "<your_certificate_path_on_device>"
+        },
+        "hashAlgorithm":"<your_hash_algorithm>",
+        "signatureAlgorithm":"<your_sig_algorithm>"
+      }
+    }
+  }
 ]
 ```
 
@@ -381,24 +390,23 @@ The output from the list\-ota\-updates command looks like this:
 
 ```
 {
-    "otaUpdates": [
-       
-        {
-            "otaUpdateId": "my_ota_update2",
-            "otaUpdateArn": "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update2",
-            "creationDate": 1522778769.042
-        },
-        {
-            "otaUpdateId": "my_ota_update1",
-            "otaUpdateArn": "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update1",
-            "creationDate": 1522775938.956
-        },
-        {
-            "otaUpdateId": "my_ota_update",
-            "otaUpdateArn": "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update",
-            "creationDate": 1522775151.031
-        }
-    ]
+  "otaUpdates": [
+    {
+      "otaUpdateId": "my_ota_update2",
+      "otaUpdateArn": "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update2",
+      "creationDate": 1522778769.042
+    },
+    {
+      "otaUpdateId": "my_ota_update1",
+      "otaUpdateArn": "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update1",
+      "creationDate": 1522775938.956
+    },
+    {
+      "otaUpdateId": "my_ota_update",
+      "otaUpdateArn": "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update",
+      "creationDate": 1522775151.031
+    }
+  ]
 }
 ```
 
@@ -414,37 +422,35 @@ Output from the get\-ota\-update command looks like this:
 
 ```
 {
-    "otaUpdateInfo": {
-        "otaUpdateId": "myotaupdate1",
-        "otaUpdateArn":
-        "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update",
-        "creationDate": 1522444438.424,
-        "lastModifiedDate": 1522444440.681,
-        "description": "a test OTA update",
-        "targets": [
-            "arn:aws:iot:us-west-2:123456789012:thing/myDevice"
-        ],
-        "targetSelection": "SNAPSHOT",
-        "otaUpdateFiles": [
-            {
-                "fileName": "app.bin",
-                "fileLocation": {
-                	"stream": {
-                    	"streamId": "003",
-                    	"fileId": 123
-                	}
-                }
-
-                "codeSigning": {
-                    "awsSignerJobId": "592932bb-24a1-4f91-8ddd-66145352ad19",
-                    "customCodeSigning": {}
-                }
-            }
-        ],
-        "otaUpdateStatus": "OTA-STATUS",
-        "awsIotJobId": "f76da3c0_10eb_41df_9029_ba7abc20f609",
-        "awsIotJobArn": "arn:aws:iot:us-west-2:123456789012:job/f76da3c0_10eb_41df_9029_ba7abc20f609"
-    }
+  "otaUpdateInfo": {
+    "otaUpdateId": "myotaupdate1",
+    "otaUpdateArn": "arn:aws:iot:us-west-2:123456789012:otaupdate/my_ota_update",
+    "creationDate": 1522444438.424,
+    "lastModifiedDate": 1522444440.681,
+    "description": "a test OTA update",
+    "targets": [
+      "arn:aws:iot:us-west-2:123456789012:thing/myDevice"
+    ],
+    "targetSelection": "SNAPSHOT",
+    "otaUpdateFiles": [
+      {
+        "fileName": "app.bin",
+        "fileLocation": {
+          "stream": {
+            "streamId": "003",
+            "fileId": 123
+          }
+        },
+        "codeSigning": {
+          "awsSignerJobId": "592932bb-24a1-4f91-8ddd-66145352ad19",
+          "customCodeSigning": {}
+        }
+      }
+    ],
+    "otaUpdateStatus": "OTA-STATUS",
+    "awsIotJobId": "f76da3c0_10eb_41df_9029_ba7abc20f609",
+    "awsIotJobArn": "arn:aws:iot:us-west-2:123456789012:job/f76da3c0_10eb_41df_9029_ba7abc20f609"
+  }
 }
 ```
 
@@ -525,9 +531,11 @@ Depending on the number of job executions created for the job and other factors,
 You can use the delete\-job\-execution to delete a job execution\. You might want to delete a job execution when a small number of devices are unable to process a job\. This deletes the job execution for a single device\. For example:
 
 ```
-aws iot delete-job-execution --job-id <your-job-id --thing-name
-					<your-thing-name> --execution-number
- <your-job-execution-number --no-force
+aws iot delete-job-execution \
+    --job-id <your-job-id \
+    --thing-name <your-thing-name> \
+    --execution-number <your-job-execution-number \
+    --no-force
 ```
 
 As with the delete\-job CLI command, you can pass the `--force` parameter to the delete\-job\-execution to force the deletion of an execution job execution\. For more information , see [DeleteJobExecution API](https://docs.aws.amazon.com/iot/latest/apireference/API_DeleteJobExecution.html)\.

--- a/doc_source/ota-code-sign-cert-esp.md
+++ b/doc_source/ota-code-sign-cert-esp.md
@@ -36,8 +36,7 @@ You need to use the AWS Command Line Interface to import your code\-signing cert
 1. Import the code\-signing certificate, private key, and certificate chain into AWS Certificate Manager:
 
    ```
-   aws acm import-certificate --certificate file://ecdsasigner.crt --private-key
-   								file://ecdsasigner.key
+   aws acm import-certificate --certificate file://ecdsasigner.crt --private-key file://ecdsasigner.key
    ```
 
    This command displays an ARN for your certificate\. You need this ARN when you create an OTA update job\.

--- a/doc_source/ota-code-sign-cert-mchip.md
+++ b/doc_source/ota-code-sign-cert-mchip.md
@@ -36,8 +36,7 @@ You need to use the AWS Command Line Interface to import your code\-signing cert
 1. Import the code\-signing certificate, private key, and certificate chain into AWS Certificate Manager:
 
    ```
-   aws acm import-certificate --certificate file://ecdsasigner.crt --private-key
-   								file://ecdsasigner.key
+   aws acm import-certificate --certificate file://ecdsasigner.crt --private-key file://ecdsasigner.key
    ```
 
    This command displays an ARN for your certificate\. You need this ARN when you create an OTA update job\.

--- a/doc_source/ota-code-sign-cert-win.md
+++ b/doc_source/ota-code-sign-cert-win.md
@@ -36,8 +36,7 @@ You need to use the AWS Command Line Interface to import your code\-signing cert
 1. Import the code\-signing certificate, private key, and certificate chain into AWS Certificate Manager:
 
    ```
-   aws acm import-certificate --certificate file://ecdsasigner.crt --private-key
-   								file://ecdsasigner.key
+   aws acm import-certificate --certificate file://ecdsasigner.crt --private-key file://ecdsasigner.key
    ```
 
    This command displays an ARN for your certificate\. You need this ARN when you create an OTA update job\.

--- a/doc_source/ota-logging.md
+++ b/doc_source/ota-logging.md
@@ -141,14 +141,14 @@ The following is an example log generated when a stream is created:
 
 ```
 { 
-	"timestamp": "2018-07-23 23:00:26.391", 
-	"logLevel": "DEBUG", 
-	"accountId": "123456789012", 
-	"status": "Success", 
-	"actionType": "CreateStream", 
-	"otaUpdateId": "3d3dc5f7-3d6d-47ac-9252-45821ac7cfb0", 
-	"streamId": "6be2303d-3637-48f0-ace9-0b87b1b9a824", 
-	"details": "Create stream. The request status is SUCCESS." 
+    "timestamp": "2018-07-23 23:00:26.391", 
+    "logLevel": "DEBUG", 
+    "accountId": "123456789012", 
+    "status": "Success", 
+    "actionType": "CreateStream", 
+    "otaUpdateId": "3d3dc5f7-3d6d-47ac-9252-45821ac7cfb0", 
+    "streamId": "6be2303d-3637-48f0-ace9-0b87b1b9a824", 
+    "details": "Create stream. The request status is SUCCESS." 
 }
 ```
 
@@ -156,13 +156,13 @@ The following is an example log generated when an OTA update is deleted:
 
 ```
 { 
-	"timestamp": "2018-07-23 23:03:09.505", 
-	"logLevel": "DEBUG", 
-	"accountId": "123456789012", 
-	"status": "Success", 
-	"actionType": "DeleteOTAUpdate", 
-	"otaUpdateId": "9bdd78fb-f113-4001-9675-1b595982292f", 
-	"details": "Delete OTA Update. The request status is SUCCESS." 
+    "timestamp": "2018-07-23 23:03:09.505", 
+    "logLevel": "DEBUG", 
+    "accountId": "123456789012", 
+    "status": "Success", 
+    "actionType": "DeleteOTAUpdate", 
+    "otaUpdateId": "9bdd78fb-f113-4001-9675-1b595982292f", 
+    "details": "Delete OTA Update. The request status is SUCCESS." 
 }
 ```
 
@@ -170,16 +170,16 @@ The following is an example log generated when a device requests a stream from t
 
 ```
 { 
-	"timestamp": "2018-07-25 22:09:02.678", 
-	"logLevel": "DEBUG", 
-	"accountId": "123456789012", 
-	"status": "Success", 
-	"actionType": "GetStream", 
-	"protocol": "MQTT", 
-	"clientId": "b9d2e49c-94fe-4ed1-9b07-286afed7e4c8", 
-	"topicName": "$aws/things/b9d2e49c-94fe-4ed1-9b07-286afed7e4c8/streams/1e51e9a8-9a4c-4c50-b005-d38452a956af/get/json", 
-	"streamId": "1e51e9a8-9a4c-4c50-b005-d38452a956af", 
-	"details": "The request status is SUCCESS." 
+    "timestamp": "2018-07-25 22:09:02.678", 
+    "logLevel": "DEBUG", 
+    "accountId": "123456789012", 
+    "status": "Success", 
+    "actionType": "GetStream", 
+    "protocol": "MQTT", 
+    "clientId": "b9d2e49c-94fe-4ed1-9b07-286afed7e4c8", 
+    "topicName": "$aws/things/b9d2e49c-94fe-4ed1-9b07-286afed7e4c8/streams/1e51e9a8-9a4c-4c50-b005-d38452a956af/get/json", 
+    "streamId": "1e51e9a8-9a4c-4c50-b005-d38452a956af", 
+    "details": "The request status is SUCCESS." 
 }
 ```
 
@@ -187,16 +187,16 @@ The following is an example log generated when a device calls the `DescribeStrea
 
 ```
 { 
-	"timestamp": "2018-07-25 22:10:12.690", 
-	"logLevel": "DEBUG", 
-	"accountId": "123456789012", 
-	"status": "Success", 
-	"actionType": "DescribeStream", 
-	"protocol": "MQTT", 
-	"clientId": "581075e0-4639-48ee-8b94-2cf304168e43", 
-	"topicName": "$aws/things/581075e0-4639-48ee-8b94-2cf304168e43/streams/71c101a8-bcc5-4929-9fe2-af563af0c139/describe/json", 
-	"streamId": "71c101a8-bcc5-4929-9fe2-af563af0c139", 
-	"clientToken": "clientToken", 
-	"details": "The request status is SUCCESS." 
+    "timestamp": "2018-07-25 22:10:12.690", 
+    "logLevel": "DEBUG", 
+    "accountId": "123456789012", 
+    "status": "Success", 
+    "actionType": "DescribeStream", 
+    "protocol": "MQTT", 
+    "clientId": "581075e0-4639-48ee-8b94-2cf304168e43", 
+    "topicName": "$aws/things/581075e0-4639-48ee-8b94-2cf304168e43/streams/71c101a8-bcc5-4929-9fe2-af563af0c139/describe/json", 
+    "streamId": "71c101a8-bcc5-4929-9fe2-af563af0c139", 
+    "clientToken": "clientToken", 
+    "details": "The request status is SUCCESS." 
 }
 ```

--- a/doc_source/policy-template.md
+++ b/doc_source/policy-template.md
@@ -4,121 +4,121 @@ The following is a policy template that grants the permissions required for AWS 
 
 ```
 {
-	"Version": "2012-10-17",
+  "Version": "2012-10-17",
     "Statement": [
-    	{
-			"Sid": "VisualEditor0",
-			"Effect": "Allow",
-			"Action": [
-				"iam:CreatePolicy",
-				"iam:DetachRolePolicy",
-				"iam:DeleteRolePolicy",
-				"s3:CreateBucket",
-				"iam:DeletePolicy",
-				"iam:CreateRole",
-				"iam:DeleteRole",
-				"iam:AttachRolePolicy",
-				"s3:DeleteBucket",
-				"s3:PutBucketVersioning"
-			],
-			"Resource": [
-				"arn:aws:s3:::idt*",
-				"arn:aws:s3:::afr-ota*",
-				"arn:aws:iam::*:policy/idt*",
-				"arn:aws:iam::*:role/idt*"
-			]
-		},
-		{
-			"Sid": "VisualEditor1",
-			"Effect": "Allow",
-			"Action": [
-				"iot:DeleteCertificate",
-				"iot:AttachPolicy",
-				"iot:DetachPolicy",
-				"s3:DeleteObjectVersion",
-				"iot:DeleteOTAUpdate",
-				"s3:PutObject",
-				"s3:GetObject",
-				"iam:PassRole",
-				"iot:DeleteStream",
-				"iot:DeletePolicy",
-				"iot:UpdateCertificate",
-				"iot:GetOTAUpdate",
-				"s3:DeleteObject",
-				"iot:DescribeJobExecution",
-				"s3:GetObjectVersion"
-			],
-			"Resource": [
-				"arn:aws:iot:*:*:thinggroup/idt*",
-				"arn:aws:iot:*:*:policy/idt*",
-				"arn:aws:iot:*:*:otaupdate/idt*",
-				"arn:aws:iot:*:*:thing/idt*",
-				"arn:aws:iot:*:*:cert/*",
-				"arn:aws:iot:*:*:job/*",
-				"arn:aws:iot:*:*:stream/*",
-				"arn:aws:iam::*:role/idt*",
-				"arn:aws:s3:::afr-ota*/*",
-				"arn:aws:s3:::idt*/*",
-				"arn:aws:iam:::role/idt*"
-			]
-		},
-		{
-			"Sid": "VisualEditor2",
-			"Effect": "Allow",
-			"Action": [
-				"iot:DetachThingPrincipal",
-				"iot:AttachThingPrincipal",
-				"s3:ListBucketVersions",
-				"iot:CreatePolicy",
-				"iam:ListRoles",
-				"freertos:ListHardwarePlatforms",
-				"signer:DescribeSigningJob",
-				"s3:ListBucket",
-				"signer:*",
-				"iot:DescribeEndpoint",
-				"iot:CreateStream",
-				"signer:StartSigningJob",
-				"s3:ListAllMyBuckets",
-				"signer:ListSigningJobs",
-				"acm:GetCertificate",
-				"acm:ListCertificates",
-				"acm:ImportCertificate",
-				"freertos:DescribeHardwarePlatform",
-				"iot:CreateKeysAndCertificate",
-				"iot:CreateCertificateFromCsr",
-				"s3:GetBucketLocation",
-				"iot:GetRegistrationCode",
-				"iot:RegisterCACertificate",
-				"iot:RegisterCertificate",
-				"iot:UpdateCACertificate",
-				"iot:DeleteCACertificate",
-				"iot:DeleteCertificate",
-				"iot:UpdateCertificate"
-			],
-			"Resource": "*"
-		},
-		{
-			"Sid": "VisualEditor3",
-			"Effect": "Allow",
-			"Action": [
-				"s3:PutObject",
-				"s3:GetObject"
-			],
-			"Resource": [
-				"arn:aws:s3:::afr*/*",
-				"arn:aws:s3:::idt*/*"
-			]
-		},
-		{
-			"Sid": "VisualEditor4",
-			"Effect": "Allow",
-			"Action": [
-				"iot:CreateOTAUpdate",
-				"iot:CreateThing",
-				"iot:DeleteThing"
-			],
-			"Resource": "*"
-		}
-	]
+      {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreatePolicy",
+        "iam:DetachRolePolicy",
+        "iam:DeleteRolePolicy",
+        "s3:CreateBucket",
+        "iam:DeletePolicy",
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:AttachRolePolicy",
+        "s3:DeleteBucket",
+        "s3:PutBucketVersioning"
+      ],
+      "Resource": [
+        "arn:aws:s3:::idt*",
+        "arn:aws:s3:::afr-ota*",
+        "arn:aws:iam::*:policy/idt*",
+        "arn:aws:iam::*:role/idt*"
+      ]
+    },
+    {
+      "Sid": "VisualEditor1",
+      "Effect": "Allow",
+      "Action": [
+        "iot:DeleteCertificate",
+        "iot:AttachPolicy",
+        "iot:DetachPolicy",
+        "s3:DeleteObjectVersion",
+        "iot:DeleteOTAUpdate",
+        "s3:PutObject",
+        "s3:GetObject",
+        "iam:PassRole",
+        "iot:DeleteStream",
+        "iot:DeletePolicy",
+        "iot:UpdateCertificate",
+        "iot:GetOTAUpdate",
+        "s3:DeleteObject",
+        "iot:DescribeJobExecution",
+        "s3:GetObjectVersion"
+      ],
+      "Resource": [
+        "arn:aws:iot:*:*:thinggroup/idt*",
+        "arn:aws:iot:*:*:policy/idt*",
+        "arn:aws:iot:*:*:otaupdate/idt*",
+        "arn:aws:iot:*:*:thing/idt*",
+        "arn:aws:iot:*:*:cert/*",
+        "arn:aws:iot:*:*:job/*",
+        "arn:aws:iot:*:*:stream/*",
+        "arn:aws:iam::*:role/idt*",
+        "arn:aws:s3:::afr-ota*/*",
+        "arn:aws:s3:::idt*/*",
+        "arn:aws:iam:::role/idt*"
+      ]
+    },
+    {
+      "Sid": "VisualEditor2",
+      "Effect": "Allow",
+      "Action": [
+        "iot:DetachThingPrincipal",
+        "iot:AttachThingPrincipal",
+        "s3:ListBucketVersions",
+        "iot:CreatePolicy",
+        "iam:ListRoles",
+        "freertos:ListHardwarePlatforms",
+        "signer:DescribeSigningJob",
+        "s3:ListBucket",
+        "signer:*",
+        "iot:DescribeEndpoint",
+        "iot:CreateStream",
+        "signer:StartSigningJob",
+        "s3:ListAllMyBuckets",
+        "signer:ListSigningJobs",
+        "acm:GetCertificate",
+        "acm:ListCertificates",
+        "acm:ImportCertificate",
+        "freertos:DescribeHardwarePlatform",
+        "iot:CreateKeysAndCertificate",
+        "iot:CreateCertificateFromCsr",
+        "s3:GetBucketLocation",
+        "iot:GetRegistrationCode",
+        "iot:RegisterCACertificate",
+        "iot:RegisterCertificate",
+        "iot:UpdateCACertificate",
+        "iot:DeleteCACertificate",
+        "iot:DeleteCertificate",
+        "iot:UpdateCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "VisualEditor3",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::afr*/*",
+        "arn:aws:s3:::idt*/*"
+      ]
+    },
+    {
+      "Sid": "VisualEditor4",
+      "Effect": "Allow",
+      "Action": [
+        "iot:CreateOTAUpdate",
+        "iot:CreateThing",
+        "iot:DeleteThing"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 ```

--- a/doc_source/qual-steps.md
+++ b/doc_source/qual-steps.md
@@ -48,10 +48,10 @@ To configure your AWS credentials using environment variables, set the `AWS_ACCE
 
 ```
 {
-	"awsRegion": "us-west-2",
-	"auth": {
-		"method": "environment"
-	}
+  "awsRegion": "us-west-2",
+  "auth": {
+    "method": "environment"
+  }
 }
 ```
 
@@ -61,13 +61,13 @@ Create a credentials file that contains your credentials\. AWS IoT Device Tester
 
 ```
 {
-	"awsRegion": "us-west-2",
-	"auth": {
-		"method": "file",
-		"credentials": {
-			"profile": "default"
-		}
-	}
+  "awsRegion": "us-west-2",
+  "auth": {
+    "method": "file",
+    "credentials": {
+      "profile": "default"
+    }
+  }
 }
 ```
 
@@ -165,46 +165,46 @@ The following is an example `device.json` file used to create a device pool with
 
 ```
 [{
-	"id": "<pool-id>",
-	"sku": "<sku>",
-	"features": [
-		{
-			"name": "WIFI",
-			"value": "Yes | No"
-		},
-		{
-			"name": "OTA",
-			"value": "Yes | No"
-		},
-		{
-			"name": "TCP/IP",
-			"value": "On-chip | Offloaded | No"
-		},
-		{
-			"name": "TLS",
-			"value": "On-chip | Offloaded | No"
-		}
-	],
-	"devices": [{
-		"id": "<device-id1>",
-		"connectivity": {
-			"protocol": "uart",
-			"serialPort": "<computer_serial_port_1>"
-		},
-		"identifiers": [{
-			"name": "serialNo",
-			"value": "<serialNo-value>"
-		}]
-		"id": "<device-id2>",
-		"connectivity": {
-			"protocol": "uart",
-			"serialPort": "<computer_serial_port_2>"
-		},
-		"identifiers": [{
-			"name": "serialNo",
-			"value": "<serialNo-value>"
-		}]
-	}]
+  "id": "<pool-id>",
+  "sku": "<sku>",
+  "features": [
+    {
+      "name": "WIFI",
+      "value": "Yes | No"
+    },
+    {
+      "name": "OTA",
+      "value": "Yes | No"
+    },
+    {
+      "name": "TCP/IP",
+      "value": "On-chip | Offloaded | No"
+    },
+    {
+      "name": "TLS",
+      "value": "On-chip | Offloaded | No"
+    }
+  ],
+  "devices": [{
+    "id": "<device-id1>",
+    "connectivity": {
+      "protocol": "uart",
+      "serialPort": "<computer_serial_port_1>"
+    },
+    "identifiers": [{
+      "name": "serialNo",
+      "value": "<serialNo-value>"
+    }]
+    "id": "<device-id2>",
+    "connectivity": {
+      "protocol": "uart",
+      "serialPort": "<computer_serial_port_2>"
+    },
+    "identifiers": [{
+      "name": "serialNo",
+      "value": "<serialNo-value>"
+    }]
+  }]
 }]
 ```
 
@@ -304,41 +304,41 @@ Build, flash, and test settings are made in the `userdata.json` file\. The follo
 
 ```
 {  
-       "sourcePath":"<absolute-path-to/amazon-freertos>",
-       "buildTool":{  
-          "name":"<your-build-tool-name>",
-          "version":"<your-build-tool-version>",
-          "command":[  
-             "<absolute-path-to/build-parallel-script> {{testData.sourcePath}}"
-          ]
-       },
-       "flashTool":{  
-          "name":"<your-flash-tool-name>",
-          "version":"<your-flash-tool-version>",
-          "command":[  
-             "<absolute-path-to/flash-parallel-script> {{testData.sourcePath}} {{device.connectivity.serialPort}}"
-          ]
-       },
-       "clientWifiConfig":{  
-          "wifiSSID":"<ssid>",
-          "wifiPassword":"<password>",
-          "wifiSecurityType":"eWiFiSecurityOpen | eWiFiSecurityWEP | eWiFiSecurityWPA | eWiFiSecurityWPA2"
-       },
-       "testWifiConfig":{  
-          "wifiSSID":"<ssid>",
-          "wifiPassword":"<password>",
-          "wifiSecurityType":"eWiFiSecurityOpen | eWiFiSecurityWEP | eWiFiSecurityWPA | eWiFiSecurityWPA2"
-       },
-       "otaConfiguration":{  
-          "otaFirmwareFilePath":"{{testData.sourcePath}}/<relative-path-to/ota-image-generated-in-build-process>",
-          "deviceFirmwareFileName":"<absolute-path-to/ota-image-on-device>",
-          "awsSignerPlatform":"AmazonFreeRTOS-Default | AmazonFreeRTOS-TI-CC3220SF",
-          "awsSignerCertificateArn":"arn:aws:acm:<region>:<account-id>:certificate:<certificate-id>",
-          "awsUntrustedSignerCertificateArn":"arn:aws:acm:<region>:<account-id>:certificate:<certificate-id>",
-          "awsSignerCertificateFileName":"<awsSignerCertificate-file-name>",
-          "compileCodesignerCertificate":true | false
-       }
-    }
+  "sourcePath":"<absolute-path-to/amazon-freertos>",
+  "buildTool":{  
+    "name":"<your-build-tool-name>",
+    "version":"<your-build-tool-version>",
+    "command":[  
+      "<absolute-path-to/build-parallel-script> {{testData.sourcePath}}"
+    ]
+  },
+  "flashTool":{  
+    "name":"<your-flash-tool-name>",
+    "version":"<your-flash-tool-version>",
+    "command":[  
+      "<absolute-path-to/flash-parallel-script> {{testData.sourcePath}} {{device.connectivity.serialPort}}"
+    ]
+  },
+  "clientWifiConfig":{  
+    "wifiSSID":"<ssid>",
+    "wifiPassword":"<password>",
+    "wifiSecurityType":"eWiFiSecurityOpen | eWiFiSecurityWEP | eWiFiSecurityWPA | eWiFiSecurityWPA2"
+  },
+  "testWifiConfig":{  
+    "wifiSSID":"<ssid>",
+    "wifiPassword":"<password>",
+    "wifiSecurityType":"eWiFiSecurityOpen | eWiFiSecurityWEP | eWiFiSecurityWPA | eWiFiSecurityWPA2"
+  },
+  "otaConfiguration":{  
+    "otaFirmwareFilePath":"{{testData.sourcePath}}/<relative-path-to/ota-image-generated-in-build-process>",
+    "deviceFirmwareFileName":"<absolute-path-to/ota-image-on-device>",
+    "awsSignerPlatform":"AmazonFreeRTOS-Default | AmazonFreeRTOS-TI-CC3220SF",
+    "awsSignerCertificateArn":"arn:aws:acm:<region>:<account-id>:certificate:<certificate-id>",
+    "awsUntrustedSignerCertificateArn":"arn:aws:acm:<region>:<account-id>:certificate:<certificate-id>",
+    "awsSignerCertificateFileName":"<awsSignerCertificate-file-name>",
+    "compileCodesignerCertificate":true | false
+  }
+}
 ```
 
 The following lists the attributes used in `userdata.json`:

--- a/doc_source/security-pkcs.md
+++ b/doc_source/security-pkcs.md
@@ -74,17 +74,19 @@ The following steps are written with the assumption that you have used the aws c
 
    ```
    {
-   	"Version": "2012-10-17",
-   	"Statement": [{
-   		"Effect": "Allow",
-   		"Action": "iot:*",
-   		"Resource": "*"
-   	},
-   	{
-   		"Effect": "Allow",
-   		"Action": "greengrass:*",
-   		"Resource": "*"
-   	}]
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": "iot:*",
+         "Resource": "*"
+       },
+       {
+        "Effect": "Allow",
+         "Action": "greengrass:*",
+         "Resource": "*"
+       }
+     ]
    }
    ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Documentation Fixes:
- Add `s3:PutObject` permission to [this example policy](https://github.com/jveldboom/aws-freertos-docs/commit/59ef173d9b32d93f7c3eed7b8b6459b1525802b2#diff-13a98a0080a5bf25d97210c9259563fdR88) which is required for code signing to save file to S3.
- Fix `platform` parameter on Amazon FreeRTOS OTA create-ota-update - [here](https://github.com/jveldboom/aws-freertos-docs/commit/59ef173d9b32d93f7c3eed7b8b6459b1525802b2#diff-ebb9dd4a804681803e72fce8011eee17R294)

Formatting changes:
- Clean up JSON formatting - like line indentions and line breaks
- Update long CLI examples to multiple lines for readability




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
