### PR TITLE
Add code signing certificate to device (ESP32 OTA)

### DIFF
--- a/doc_source/userguide/burn-initial-firmware-esp.md
+++ b/doc_source/userguide/burn-initial-firmware-esp.md
@@ -8,8 +8,8 @@ This guide is written with the assumption that you have already performed the st
 
 1. Copy your SHA-256/ECDSA PEM-formatted code-signing certificate that you generated in the [Over\-the\-Air Update Prerequisites](https://docs.aws.amazon.com/freertos/latest/userguide/ota-prereqs.html) to `demos/include/aws_ota_codesigner_certificate.h`. It should be formatted in the following way:
    ```
-   static const char signingcredentialSIGNING_CERTIFICATE_PEM[] = "-----BEGIN CERTIFICATE-----\n
-   ...base64 data...\n
+   static const char signingcredentialSIGNING_CERTIFICATE_PEM[] = "-----BEGIN CERTIFICATE-----\n"
+   ...base64 data...\n"
    -----END CERTIFICATE-----\n";
    ```
 

--- a/doc_source/userguide/burn-initial-firmware-esp.md
+++ b/doc_source/userguide/burn-initial-firmware-esp.md
@@ -6,6 +6,13 @@ This guide is written with the assumption that you have already performed the st
 
 1. In `demos/common/demo_runner/aws_demo_runner.c`, in the `DEMO_RUNNER_RunDemos` function, comment out all functions calls except `vStartOTAUpdateDemoTask`\.
 
+1. Copy your SHA-256/ECDSA PEM-formatted code-signing certificate that you generated in the [Over\-the\-Air Update Prerequisites](https://docs.aws.amazon.com/freertos/latest/userguide/ota-prereqs.html) to `demos/include/aws_ota_codesigner_certificate.h`. It should be formatted in the following way:
+   ```
+   static const char signingcredentialSIGNING_CERTIFICATE_PEM[] = "-----BEGIN CERTIFICATE-----\n\
+   ...base64 data...\n\
+   -----END CERTIFICATE-----\n";
+   ```
+
 1. With the OTA Update demo selected, follow the same steps outlined in [Getting Started with ESP32](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_espressif.html) to build and flash the image\. If you have previously built and flashed the project, you might need to run `make clean` first\. After you run `make flash monitor`, you should see something like the following\. The ordering of some messages might vary, because the demo application runs multiple tasks at once:
 
    ```

--- a/doc_source/userguide/burn-initial-firmware-esp.md
+++ b/doc_source/userguide/burn-initial-firmware-esp.md
@@ -8,8 +8,8 @@ This guide is written with the assumption that you have already performed the st
 
 1. Copy your SHA-256/ECDSA PEM-formatted code-signing certificate that you generated in the [Over\-the\-Air Update Prerequisites](https://docs.aws.amazon.com/freertos/latest/userguide/ota-prereqs.html) to `demos/include/aws_ota_codesigner_certificate.h`. It should be formatted in the following way:
    ```
-   static const char signingcredentialSIGNING_CERTIFICATE_PEM[] = "-----BEGIN CERTIFICATE-----\n\
-   ...base64 data...\n\
+   static const char signingcredentialSIGNING_CERTIFICATE_PEM[] = "-----BEGIN CERTIFICATE-----\n
+   ...base64 data...\n
    -----END CERTIFICATE-----\n";
    ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Instructions to add the code signing certificate to the OTA tutorial. (instructions are mentioned here: https://github.com/awsdocs/aws-freertos-docs/blob/master/doc_source/userguide/download-ota-esp.md but this is a different page that is not listed in the step-by-step OTA tutorial)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
