### PR TITLE
Private key does not belong in device OTA config

### DIFF
--- a/doc_source/userguide/ota-code-sign-cert-other.md
+++ b/doc_source/userguide/ota-code-sign-cert-other.md
@@ -14,4 +14,4 @@ The output from this command displays an ARN for your certificate\. You need thi
 
 ACM requires certificates to use specific algorithms and key sizes\. For more information, see [Prerequisites for Importing Certificates](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate-prerequisites.html)\. For more information about ACM, see [Importing Certificates into AWS Certificate Manager](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate.html)\.
 
-You must copy, paste, and format the contents of your code\-signing certificate and private key into the `aws_ota_codesigner_certificate.h` file that is part of the FreeRTOS code you download later\.
+You must copy, paste, and format the contents of your code\-signing certificate into the `aws_ota_codesigner_certificate.h` file that is part of the FreeRTOS code you download later\.


### PR DESCRIPTION
The wording that one should include the **private key** into `aws_ota_codesigner_certificate.h` is surely incorrect? AFAICT only the (public) certificate should be needed on the device.

The documentation and sample code for the [OTA tests](https://github.com/aws/amazon-freertos/blob/master/libraries/freertos_plus/aws/ota/test/README.md) also appears to confirm this:

> Currently tests/common/include/aws_ota_codesigner_certificate.h is pre-filled in with the ecdsa-sha256-signer.crt.pem certificate located under tests/common/ota/test_files.

…the `ecdsa-sha256-signer.crt.pem` *certificate* being very distinct from the `rsa-sha256-signer.key.pem` *private key*. Only the former is included in the [codesign configuration header](https://github.com/aws/amazon-freertos/blob/master/libraries/freertos_plus/aws/ota/test/aws_ota_codesigner_certificate.h
) which is built into the device.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
