### PR TITLE
freertos-getting-started-demo: minor typo in demo file name

### DIFF
--- a/doc_source/userguide/freertos-getting-started-demo.md
+++ b/doc_source/userguide/freertos-getting-started-demo.md
@@ -1,6 +1,6 @@
 # FreeRTOS demo application<a name="freertos-getting-started-demo"></a>
 
-The demo application in this tutorial is the coreMQTT Mutual Authentication demo defined in the `/demos/coreMQTT/mqtt_demo-mutual_auth.c` file\. It uses the [coreMQTT library](coremqtt.md) to connect to the AWS Cloud and then periodically publish messages to an MQTT topic hosted by the [AWS IoT MQTT broker](https://docs.aws.amazon.com/iot/latest/developerguide/mqtt.html)\.
+The demo application in this tutorial is the coreMQTT Mutual Authentication demo defined in the `/demos/coreMQTT/mqtt_demo_mutual_auth.c` file\. It uses the [coreMQTT library](coremqtt.md) to connect to the AWS Cloud and then periodically publish messages to an MQTT topic hosted by the [AWS IoT MQTT broker](https://docs.aws.amazon.com/iot/latest/developerguide/mqtt.html)\.
 
 Only a single FreeRTOS demo application can run at a time\. When you build a FreeRTOS demo project, the first demo enabled in the `freertos/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h` header file is the application that runs\. For this tutorial, you do not need to enable or disable any demos\. The coreMQTT Mutual Authentication demo is enabled by default\.
 


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This is just a minor typo

The original doc mention a file called `/demos/coreMQTT/mqtt_demo-mutual_auth.c`,
but the actual file name has an underscore between `demo` and `mutual`: https://github.com/aws/amazon-freertos/blob/0ca40061d0912c8fe4cc1bcce91ad4537cd32a36/demos/coreMQTT/mqtt_demo_mutual_auth.c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
